### PR TITLE
Update database.rb active record connection

### DIFF
--- a/config/database.rb
+++ b/config/database.rb
@@ -9,6 +9,6 @@ ActiveRecord::Base.establish_connection(
   :port     => db.port,
   :username => db.user,
   :password => db.password,
-  :database => "#{database_name}",
+  :database => db.path[1..-1],
   :encoding => 'utf8'
 )


### PR DESCRIPTION
This change will allow Heroku to find the correct database. 

The `database_name` variable will be `traffic-spy-production` on Heroku and that won't exist because Heroku uses a different database name in production.

It will also still work in development and test.
